### PR TITLE
Handle factories without valid classes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-18
 
 DEPENDENCIES
@@ -82,4 +83,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   2.2.3
+   2.4.10

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    factory_burgers (1.0.0)
+    factory_burgers (1.1.0)
       factory_bot (>= 4)
       rack (>= 1)
 

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ eslint:
 
 test: rubocop eslint rspec
 
+test_all: -rubocop -eslint -rspec
+
 assets:
 	cd factory_burgers-ui; npm run build
 
@@ -26,3 +28,6 @@ gem: factory_burgers-$(VERSION).gem
 
 publish: assets test factory_burgers-$(VERSION).gem
 	gem push factory_burgers-$(VERSION).gem
+
+-%:
+	-@$(MAKE) $*

--- a/lib/factory_burgers.rb
+++ b/lib/factory_burgers.rb
@@ -4,7 +4,7 @@ Dir[Pathname(__dir__).join("factory_burgers/**/*.rb")].sort.each do |file|
   require file
 end
 
-#:nodoc:
+# :nodoc:
 module FactoryBurgers
   class << self
     delegate :run_initializers, to: :initializer

--- a/lib/factory_burgers/cheating.rb
+++ b/lib/factory_burgers/cheating.rb
@@ -36,7 +36,7 @@ module FactoryBurgers
     end
 
     def find_highest_index_value(klass, column, sql, regex)
-      matches = klass.where(sql).pluck(column).select { |val| val =~ regex }
+      matches = klass.where(sql).pluck(column).grep(regex)
       return matches.map { |value| value =~ regex && Regexp.last_match(1) }.map(&:to_i).max
     end
 

--- a/lib/factory_burgers/factory_bot_adapter.rb
+++ b/lib/factory_burgers/factory_bot_adapter.rb
@@ -50,7 +50,7 @@ module FactoryBurgers
   end
 
   module FactoryBotAdapters
-    #:nodoc:
+    # :nodoc:
     class FactoryBotV6
       def load_factories
         FactoryBot.reload

--- a/lib/factory_burgers/introspection.rb
+++ b/lib/factory_burgers/introspection.rb
@@ -23,6 +23,9 @@ module FactoryBurgers
     def factories_for_class(klass)
       factories.select do |factory|
         factory.build_class.ancestors.include?(klass)
+      rescue NameError
+        # Some usages of factories include pseudo "abstract" factory parent classes that do not point to a real class
+        false
       end
     end
 

--- a/lib/factory_burgers/middleware/build.rb
+++ b/lib/factory_burgers/middleware/build.rb
@@ -40,7 +40,7 @@ module FactoryBurgers
         return [] if attribute_items.nil?
 
         attribute_items = attribute_items.select { |attr| attr["name"].present? }
-        return attribute_items.map { |attr| [attr["name"], attr["value"]] }.to_h
+        return attribute_items.to_h { |attr| [attr["name"], attr["value"]] }
       end
 
       def get_resource_owner(owner_type, owner_id)

--- a/lib/factory_burgers/middleware/data.rb
+++ b/lib/factory_burgers/middleware/data.rb
@@ -5,13 +5,14 @@ module FactoryBurgers
     # Respond with factory data to display in the main form
     class Data
       def call(*)
-        factories = FactoryBurgers.factory_bot_adapter.factories.sort_by(&:name)
-        factory_data = factories.map { |factory| factory_data(factory) }
+        factories = FactoryBurgers::Introspection.factories
+        models = factories.map { |factory| factory_model(factory) }.select(&:valid?)
+        factory_data = models.map(&:to_h)
         return [200, {"Content-Type" => "application/json"}, [JSON.dump(factory_data)]]
       end
 
-      def factory_data(factory)
-        FactoryBurgers::Models::Factory.new(factory).to_h
+      def factory_model(factory)
+        FactoryBurgers::Models::Factory.new(factory)
       end
     end
   end

--- a/lib/factory_burgers/models/factory.rb
+++ b/lib/factory_burgers/models/factory.rb
@@ -21,8 +21,8 @@ module FactoryBurgers
         }
       end
 
-      def to_json(*opts, &blk)
-        to_h.to_json(*opts, &blk)
+      def to_json(...)
+        to_h.to_json(...)
       end
 
       def name
@@ -56,7 +56,7 @@ module FactoryBurgers
       end
     end
 
-    #:nodoc:
+    # :nodoc:
     class Attribute
       attr_reader :column
 
@@ -68,8 +68,8 @@ module FactoryBurgers
         {name: name}
       end
 
-      def to_json(*opts, &blk)
-        to_h.to_json(*opts, &blk)
+      def to_json(...)
+        to_h.to_json(...)
       end
 
       def name
@@ -77,7 +77,7 @@ module FactoryBurgers
       end
     end
 
-    #:nodoc:
+    # :nodoc:
     class Trait
       attr_reader :trait
 
@@ -89,8 +89,8 @@ module FactoryBurgers
         {name: name}
       end
 
-      def to_json(*opts, &blk)
-        to_h.to_json(*opts, &blk)
+      def to_json(...)
+        to_h.to_json(...)
       end
 
       def name

--- a/lib/factory_burgers/models/factory.rb
+++ b/lib/factory_burgers/models/factory.rb
@@ -12,6 +12,10 @@ module FactoryBurgers
         @factory = factory
       end
 
+      def valid?
+        build_class.present?
+      end
+
       def to_h
         {
           name: name,
@@ -45,6 +49,9 @@ module FactoryBurgers
 
       def build_class
         factory.build_class
+      rescue NameError
+        # Some usages of factories include pseudo "abstract" factory parent classes that do not point to a real class
+        nil
       end
 
       def settable_columns

--- a/lib/factory_burgers/version.rb
+++ b/lib/factory_burgers/version.rb
@@ -1,3 +1,3 @@
 module FactoryBurgers
-  VERSION = '1.0.0'.freeze
+  VERSION = '1.1.0'.freeze
 end

--- a/spec/factories/phony_factories.rb
+++ b/spec/factories/phony_factories.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :phony do
+    # nothing here, and no class to back it up.
+  end
+end

--- a/spec/lib/factory_burgers/cheating_spec.rb
+++ b/spec/lib/factory_burgers/cheating_spec.rb
@@ -26,7 +26,7 @@ describe FactoryBurgers::Cheating do
       allow(klass).to receive(:pluck).with(:foo).and_return(%w[foo1 foo5])
 
       FactoryBurgers::Cheating.advance_sequence(:sequence, klass, :foo)
-      next_foo = FactoryBot.generate(:sequence)
+      next_foo = generate(:sequence)
       expect(next_foo).to eq("foo6")
     end
 

--- a/spec/lib/factory_burgers/models/factory_spec.rb
+++ b/spec/lib/factory_burgers/models/factory_spec.rb
@@ -20,6 +20,18 @@ describe FactoryBurgers::Models::Factory do
     expect(blueprint.attributes.map(&:name)).to include("name")
   end
 
+  describe "valid?" do
+    it "is true for a regular factory" do
+      expect(blueprint).to be_valid
+    end
+
+    it "is false when the factory class is not defined" do
+      factory = FactoryBot::Internal.factories.find(:phony)
+      blueprint = FactoryBurgers::Models::Factory.new(factory)
+      expect(blueprint).not_to be_valid
+    end
+  end
+
   describe "to_h" do
     it "converts to a Hash" do
       expect(blueprint.to_h).to include({name: "user", class_name: "User"})

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require "active_record"
 require "byebug"
 require "factory_bot"
+require 'pathname'
 require "rack"
 
 require "factory_burgers"


### PR DESCRIPTION
Some factory use cases build factories that do not have valid classes. E.g. as a pseudo-abstract parent factory. Reject these from factory_data, as they have none.

Bump version 1.0.0 -> 1.1.0

includes updates to makefile for better local dev